### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a PandaDoc connector
 og:title: Set up a PandaDoc connector - C1 docs
-og:description: Integrate your PandaDoc instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-description: C1 provides identity governance and just-in-time provisioning for PandaDoc. Integrate your PandaDoc instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
+og:description: "C1 provides identity governance for PandaDoc. Integrate your PandaDoc instance with C1 for unified visibility and governance over user access."
+description: "C1 provides identity governance for PandaDoc. Integrate your PandaDoc instance with C1 for unified visibility and governance over user access."
 sidebarTitle: PandaDoc
 ---
 
@@ -35,7 +35,7 @@ In the **API keys** area of the page, create a sandbox or production API key ([p
 Carefully copy and save the API key. 
 </Step>
 </Steps>
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the PandaDoc connector
 
@@ -93,7 +93,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your PandaDoc connector is now pulling access data into C1.
+**Done.** Your PandaDoc connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the PandaDoc connector, hosted and run in your own environment.**
@@ -209,7 +209,7 @@ Create a namespace in which to run C1 connectors (if desired), then apply the se
 Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the PandaDoc connector to. PandaDoc data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
-**That's it!** Your PandaDoc connector is now pulling access data into C1.
+**Done.** Your PandaDoc connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines