### PR TITLE
fix: mark api-key as isSecret in config schema

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ var Config = field.NewConfiguration([]field.SchemaField{
 	field.StringField(
 		"api-key",
 		field.WithRequired(true),
+		field.WithIsSecret(true),
 		field.WithDescription("PandaDoc account API-Key"),
 	),
 	field.BoolField(


### PR DESCRIPTION
## Summary

Marks credential field(s) `api-key` (PandaDoc account API key) as secret in this connector's config so the credential is stored and handled as a secret rather than plaintext.

This connector defines its config in Go (`field` package), not a `config.yaml`. Secret-ness is the `field.WithIsSecret(true)` option on the field — the authoritative source. There is no committed `config_schema.json` in this repo, and the generated `conf.gen.go` is a mapstructure struct that carries no secret metadata, so the one-line `config.go` change is the complete fix and a CI regen produces no additional diff (no race).

## BREAKING

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

## Audit

Part of the connector config secret-ness audit (phase 13). Found via systematic review of credential fields lacking `isSecret`.

Do not merge — left open for review.

<!-- stargate: connector-secret-audit-phase13 -->