### PR TITLE
CXH-1890: containerize connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 dist/
+/baton-panda-doc

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOOS = $(shell go env GOOS)
 GOARCH = $(shell go env GOARCH)
 BUILD_DIR = dist/${GOOS}_${GOARCH}
-GENERATED_CONF = pkg/config/conf.gen.go
+GENERATED_CONF := pkg/config/conf.gen.go
 
 ifeq ($(GOOS),windows)
 OUTPUT_PATH = ${BUILD_DIR}/baton-panda-doc.exe
@@ -9,16 +9,21 @@ else
 OUTPUT_PATH = ${BUILD_DIR}/baton-panda-doc
 endif
 
+ifdef BATON_LAMBDA_SUPPORT
+	BUILD_TAGS=-tags baton_lambda_support
+else
+	BUILD_TAGS=
+endif
+
 .PHONY: build
 build: $(GENERATED_CONF)
-	go build -o ${OUTPUT_PATH} ./cmd/baton-panda-doc
+	go build ${BUILD_TAGS} -o ${OUTPUT_PATH} ./cmd/baton-panda-doc
 
 $(GENERATED_CONF): pkg/config/config.go go.mod
+	@echo "Generating $(GENERATED_CONF)..."
 	go generate ./pkg/config
 
-.PHONY: generate
-generate:
-	go generate ./pkg/config
+generate: $(GENERATED_CONF)
 
 .PHONY: update-deps
 update-deps:
@@ -26,8 +31,8 @@ update-deps:
 	go mod tidy -v
 	go mod vendor
 
-.PHONY: add-dep
-add-dep:
+.PHONY: add-deps
+add-deps:
 	go mod tidy -v
 	go mod vendor
 

--- a/cmd/baton-panda-doc/main.go
+++ b/cmd/baton-panda-doc/main.go
@@ -2,61 +2,19 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	cfg "github.com/conductorone/baton-panda-doc/pkg/config"
 	"github.com/conductorone/baton-panda-doc/pkg/connector"
 	"github.com/conductorone/baton-sdk/pkg/config"
-	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 	"github.com/conductorone/baton-sdk/pkg/connectorrunner"
-	"github.com/conductorone/baton-sdk/pkg/types"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 )
 
 var version = "dev"
 
 func main() {
 	ctx := context.Background()
-
-	_, cmd, err := config.DefineConfiguration(
-		ctx,
-		"baton-panda-doc",
-		getConnector,
-		cfg.Config,
-		connectorrunner.WithDefaultCapabilitiesConnectorBuilder(&connector.Connector{}),
+	config.RunConnector(ctx, "baton-panda-doc", version, cfg.Config,
+		connector.NewLambdaConnector,
+		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.Connector{}),
 	)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-
-	cmd.Version = version
-
-	err = cmd.Execute()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
-}
-
-func getConnector(ctx context.Context, pc *cfg.PandaDoc) (types.ConnectorServer, error) {
-	l := ctxzap.Extract(ctx)
-
-	if err := cfg.ValidateConfig(pc); err != nil {
-		return nil, err
-	}
-
-	cb, err := connector.New(ctx, pc.EuropeDomain, pc.ApiKey, pc.BaseUrl)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-	connector, err := connectorbuilder.NewConnector(ctx, cb)
-	if err != nil {
-		l.Error("error creating connector", zap.Error(err))
-		return nil, err
-	}
-	return connector, nil
 }

--- a/cmd/baton-panda-doc/main.go
+++ b/cmd/baton-panda-doc/main.go
@@ -16,5 +16,6 @@ func main() {
 	config.RunConnector(ctx, "baton-panda-doc", version, cfg.Config,
 		connector.NewLambdaConnector,
 		connectorrunner.WithDefaultCapabilitiesConnectorBuilderV2(&connector.Connector{}),
+		connectorrunner.WithSessionStoreEnabled(),
 	)
 }

--- a/config_schema.json
+++ b/config_schema.json
@@ -107,6 +107,7 @@
     },
     {
       "name": "europe-domain",
+      "displayName": "Use PandaDoc Europe domain",
       "description": "PandaDoc API domain. Set to true for europe domain (false by default).",
       "boolField": {}
     }

--- a/config_schema.json
+++ b/config_schema.json
@@ -94,7 +94,9 @@
     },
     {
       "name": "api-key",
+      "displayName": "API Key",
       "description": "PandaDoc account API-Key",
+      "placeholder": "Enter your PandaDoc API key",
       "isRequired": true,
       "isSecret": true,
       "stringField": {
@@ -108,5 +110,8 @@
       "description": "PandaDoc API domain. Set to true for europe domain (false by default).",
       "boolField": {}
     }
-  ]
+  ],
+  "displayName": "PandaDoc",
+  "helpUrl": "/docs/baton/panda-doc",
+  "iconUrl": "/static/app-icons/panda-doc.svg"
 }

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -18,24 +18,42 @@ sidebarTitle: PandaDoc
 
 Each setup method requires you to pass in credentials generated in PandaDoc. Gather these credentials before you move on. 
 
-<Warning>
-A an **Org Admin*** in PandaDoc must perform this task.
-</Warning>
-
 ### Generate an API key
+
+<Note>
+Only a PandaDoc **account owner** or **admin** can access Dev Center and generate API keys.
+</Note>
 
 <Steps>
 <Step>
-In PandaDoc, navigate to **Dev center** and click **Configuration**. 
+**Enable Dev Center (Business plan only).** If your organization is on the Business plan, Dev Center must be enabled before it appears in the navigation. In PandaDoc, go to **Settings** → **API and Integrations** → **API** and click **Enable**. This provides access to the Sandbox environment only.
+
+Enterprise plan accounts have Dev Center enabled by default.
 </Step>
 <Step>
-In the **API keys** area of the page, create a sandbox or production API key ([production keys require approval from the PandaDoc team](https://developers.pandadoc.com/reference/production-api-key)). 
+In PandaDoc, navigate to **Dev Center** → **Configuration**.
 </Step>
 <Step>
-Carefully copy and save the API key. 
+In the **API keys** area, generate a **Sandbox** or **Production** API key.
+
+<Note>
+Production API keys require an active **Enterprise plan**. On Business plans, only Sandbox keys are available.
+</Note>
+</Step>
+<Step>
+Carefully copy and save the API key.
 </Step>
 </Steps>
-**Done.** Next, move on to the connector configuration instructions. 
+
+**Done.** Next, move on to the connector configuration instructions.
+
+<Accordion title="Troubleshooting: Dev Center not visible">
+If **Dev Center** doesn't appear in your PandaDoc navigation:
+
+- **Check your role.** Only account owners and admins can see and use Dev Center.
+- **Check if it's enabled.** On Business plans, Dev Center must be manually enabled under **Settings** → **API and Integrations** → **API**.
+- **Check your plan.** Dev Center is available on Business and Enterprise plans only.
+</Accordion>
 
 ## Configure the PandaDoc connector
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -80,7 +80,7 @@ Click **Next**.
 Find the **Settings** area of the page and click **Edit**.
 </Step>
 <Step>
-Enter the API key in the **PandaDoc API key** field. 
+Enter the API key in the **API Key** field. 
 </Step>
 <Step>
 If you use PanadaDoc's European API instance, check the **Use PandaDoc Europe domain** box. 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -47,13 +47,15 @@ Carefully copy and save the API key.
 
 **Done.** Next, move on to the connector configuration instructions.
 
-<Accordion title="Troubleshooting: Dev Center not visible">
+<Note>
+**Troubleshooting: Dev Center not visible**
+
 If **Dev Center** doesn't appear in your PandaDoc navigation:
 
 - **Check your role.** Only account owners and admins can see and use Dev Center.
 - **Check if it's enabled.** On Business plans, Dev Center must be manually enabled under **Settings** → **API and Integrations** → **API**.
 - **Check your plan.** Dev Center is available on Business and Enterprise plans only.
-</Accordion>
+</Note>
 
 ## Configure the PandaDoc connector
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ var Config = field.NewConfiguration([]field.SchemaField{
 	),
 	field.BoolField(
 		"europe-domain",
+		field.WithDisplayName("Use PandaDoc Europe domain"),
 		field.WithDescription("PandaDoc API domain. Set to true for europe domain (false by default)."),
 		field.WithDefaultValue(false),
 	),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,8 @@ var Config = field.NewConfiguration([]field.SchemaField{
 		field.WithRequired(true),
 		field.WithIsSecret(true),
 		field.WithDescription("PandaDoc account API-Key"),
+		field.WithDisplayName("API Key"),
+		field.WithPlaceholder("Enter your PandaDoc API key"),
 	),
 	field.BoolField(
 		"europe-domain",
@@ -24,7 +26,11 @@ var Config = field.NewConfiguration([]field.SchemaField{
 		field.WithHidden(true),
 		field.WithExportTarget(field.ExportTargetCLIOnly),
 	),
-})
+},
+	field.WithConnectorDisplayName("PandaDoc"),
+	field.WithIconUrl("/static/app-icons/panda-doc.svg"),
+	field.WithHelpUrl("/docs/baton/panda-doc"),
+)
 
 func ValidateConfig(c *PandaDoc) error {
 	return nil

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -7,10 +7,12 @@ import (
 	"sync"
 	"time"
 
+	cfg "github.com/conductorone/baton-panda-doc/pkg/config"
 	"github.com/conductorone/baton-panda-doc/pkg/client"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
+	"github.com/conductorone/baton-sdk/pkg/cli"
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 )
 
@@ -61,9 +63,9 @@ func (c *Connector) cacheUsers(ctx context.Context) error {
 	return nil
 }
 
-// ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
-func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
-	return []connectorbuilder.ResourceSyncer{
+// ResourceSyncers returns a ResourceSyncerV2 for each resource type that should be synced from the upstream service.
+func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
+	return []connectorbuilder.ResourceSyncerV2{
 		newUserBuilder(d.client, d),
 		newWorkspaceBuilder(d.client, d),
 		newRolesBuilder(d.client, d),
@@ -104,4 +106,13 @@ func New(ctx context.Context, europeDomain bool, apiKey string, baseURL string) 
 	}
 
 	return &Connector{client: pandaDocClient}, nil
+}
+
+// NewLambdaConnector creates a new connector from config for use with lambda/containerized deployments.
+func NewLambdaConnector(ctx context.Context, ac *cfg.PandaDoc, _ *cli.ConnectorOpts) (connectorbuilder.ConnectorBuilderV2, []connectorbuilder.Opt, error) {
+	cb, err := New(ctx, ac.EuropeDomain, ac.ApiKey, ac.BaseUrl)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cb, nil, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -3,9 +3,6 @@ package connector
 import (
 	"context"
 	"io"
-	"strconv"
-	"sync"
-	"time"
 
 	cfg "github.com/conductorone/baton-panda-doc/pkg/config"
 	"github.com/conductorone/baton-panda-doc/pkg/client"
@@ -16,59 +13,18 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/connectorbuilder"
 )
 
-const TTL = 5 // in minutes
 const usersPageSize = 50
 
 type Connector struct {
-	client         *client.PandaDocClient
-	cachedUsers    []client.User
-	cacheTimestamp time.Time
-	usersMtx       sync.Mutex
-}
-
-func (c *Connector) cacheUsers(ctx context.Context) error {
-	c.usersMtx.Lock()
-	defer c.usersMtx.Unlock()
-
-	if c.cachedUsers != nil && time.Since(c.cacheTimestamp) < TTL*time.Minute {
-		return nil
-	}
-
-	var usersToCache []client.User
-	pageOptions := client.PageOptions{
-		Count: usersPageSize,
-		Page:  1,
-	}
-
-	for {
-		users, nextPageToken, _, err := c.client.ListUsers(ctx, pageOptions)
-		if err != nil {
-			return err
-		}
-		usersToCache = append(usersToCache, users...)
-
-		if nextPageToken == "" {
-			break
-		} else {
-			pageToken, err := strconv.Atoi(nextPageToken)
-			if err != nil {
-				return err
-			}
-			pageOptions.Page = pageToken
-		}
-	}
-
-	c.cachedUsers = usersToCache
-	c.cacheTimestamp = time.Now()
-	return nil
+	client *client.PandaDocClient
 }
 
 // ResourceSyncers returns a ResourceSyncerV2 for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	return []connectorbuilder.ResourceSyncerV2{
-		newUserBuilder(d.client, d),
-		newWorkspaceBuilder(d.client, d),
-		newRolesBuilder(d.client, d),
+		newUserBuilder(d.client),
+		newWorkspaceBuilder(d.client),
+		newRolesBuilder(d.client),
 	}
 }
 

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/conductorone/baton-panda-doc/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
@@ -29,14 +28,14 @@ func (rb *roleBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 
 // There is no endpoint for Roles.
 // There are 4 system roles and custom roles can be created. We'll retrieve custom roles names from the users list.
-func (rb *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (rb *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	var rolesResource []*v2.Resource
 
 	for _, role := range systemRoles {
 		roleCopy := role
 		roleResource, err := parseIntoRoleResource(ctx, &roleCopy, nil)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 		rolesResource = append(rolesResource, roleResource)
 	}
@@ -44,7 +43,7 @@ func (rb *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 	err := rb.connector.cacheUsers(ctx)
 
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	systemRoles := []string{"Admin", "Collaborator", "Member", "Manager"}
@@ -60,23 +59,23 @@ func (rb *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 				}
 				roleResource, err := parseIntoRoleResource(ctx, &newRole, nil)
 				if err != nil {
-					return nil, "", nil, err
+					return nil, nil, err
 				}
 				rolesResource = append(rolesResource, roleResource)
 			}
 		}
 	}
 
-	return rolesResource, "", nil, nil
+	return rolesResource, nil, nil
 }
 
-func (rb *roleBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (rb *roleBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 
 	err := rb.GetWorkspaces(ctx)
 
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	workspaces := rb.workspaces
@@ -92,16 +91,16 @@ func (rb *roleBuilder) Entitlements(ctx context.Context, resource *v2.Resource, 
 		rv = append(rv, entitlement.NewPermissionEntitlement(resource, permissionName, assigmentOptions...))
 	}
 
-	return rv, "", nil, nil
+	return rv, nil, nil
 }
 
-func (rb *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (rb *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	var grants []*v2.Grant
 
 	err := rb.connector.cacheUsers(ctx)
 
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	users := rb.connector.cachedUsers
@@ -110,7 +109,7 @@ func (rb *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 			if workspace.Role == resource.Id.Resource {
 				workspaceName, err := rb.GetWorkspaceName(ctx, workspace.WorkspaceID)
 				if err != nil {
-					return nil, "", nil, err
+					return nil, nil, err
 				}
 				entitlementName := fmt.Sprintf("assigned in workspace %s", workspaceName)
 				userResource, _ := parseIntoUserResource(ctx, &user, resource.Id)
@@ -122,7 +121,7 @@ func (rb *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken
 		}
 	}
 
-	return grants, "", nil, nil
+	return grants, nil, nil
 }
 
 func newRolesBuilder(client *client.PandaDocClient, con *Connector) *roleBuilder {

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -10,6 +10,8 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
 )
 
 type roleBuilder struct {
@@ -101,10 +103,19 @@ func (rb *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, opts r
 		wsNames[w.ID] = w.Name
 	}
 
+	l := ctxzap.Extract(ctx)
 	for _, user := range users {
 		for _, workspace := range user.Workspaces {
 			if workspace.Role == resource.Id.Resource {
-				entitlementName := fmt.Sprintf("assigned in workspace %s", wsNames[workspace.WorkspaceID])
+				wsName, ok := wsNames[workspace.WorkspaceID]
+				if !ok {
+					l.Warn("baton-panda-doc: skipping grant for unknown workspace",
+						zap.String("workspace_id", workspace.WorkspaceID),
+						zap.String("user_id", user.ID),
+					)
+					continue
+				}
+				entitlementName := fmt.Sprintf("assigned in workspace %s", wsName)
 				userResource, _ := parseIntoUserResource(ctx, &user, resource.Id)
 				membershipGrant := grant.NewGrant(resource, entitlementName, userResource, grant.WithAnnotation(&v2.V1Identifier{
 					Id: fmt.Sprintf("workspace-grant:%s:%s:%s", resource.Id.Resource, workspace.MembershipID, workspace.Role),

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/conductorone/baton-panda-doc/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
@@ -63,10 +62,10 @@ func (rb *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 	return rolesResource, nil, nil
 }
 
-func (rb *roleBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+func (rb *roleBuilder) Entitlements(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 
-	workspaces, err := rb.GetWorkspaces(ctx)
+	workspaces, err := getWorkspacesFromSession(ctx, rb.client, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -93,14 +92,19 @@ func (rb *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, opts r
 		return nil, nil, err
 	}
 
+	workspaces, err := getWorkspacesFromSession(ctx, rb.client, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	wsNames := make(map[string]string, len(workspaces))
+	for _, w := range workspaces {
+		wsNames[w.ID] = w.Name
+	}
+
 	for _, user := range users {
 		for _, workspace := range user.Workspaces {
 			if workspace.Role == resource.Id.Resource {
-				workspaceName, err := rb.GetWorkspaceName(ctx, workspace.WorkspaceID)
-				if err != nil {
-					return nil, nil, err
-				}
-				entitlementName := fmt.Sprintf("assigned in workspace %s", workspaceName)
+				entitlementName := fmt.Sprintf("assigned in workspace %s", wsNames[workspace.WorkspaceID])
 				userResource, _ := parseIntoUserResource(ctx, &user, resource.Id)
 				membershipGrant := grant.NewGrant(resource, entitlementName, userResource, grant.WithAnnotation(&v2.V1Identifier{
 					Id: fmt.Sprintf("workspace-grant:%s:%s:%s", resource.Id.Resource, workspace.MembershipID, workspace.Role),
@@ -139,53 +143,3 @@ func parseIntoRoleResource(_ context.Context, role *client.Role, _ *v2.ResourceI
 	return ret, nil
 }
 
-func (rb *roleBuilder) GetWorkspaces(ctx context.Context) ([]client.Workspace, error) {
-	paginationToken := pagination.Token{
-		Size:  wsPageSize,
-		Token: "",
-	}
-
-	var workspaces []client.Workspace
-	for {
-		bag, pageToken, err := getToken(&paginationToken, workspaceResourceType)
-		if err != nil {
-			return nil, err
-		}
-		page, nextPageToken, _, err := rb.client.ListWorkspaces(ctx, client.PageOptions{
-			Count: paginationToken.Size,
-			Page:  pageToken,
-		})
-		if err != nil {
-			return nil, err
-		}
-		err = bag.Next(nextPageToken)
-		if err != nil {
-			return nil, err
-		}
-
-		workspaces = append(workspaces, page...)
-		nextPageToken, err = bag.Marshal()
-		if err != nil {
-			return nil, err
-		}
-		if nextPageToken == "" {
-			break
-		}
-		paginationToken.Token = nextPageToken
-	}
-
-	return workspaces, nil
-}
-
-func (rb *roleBuilder) GetWorkspaceName(ctx context.Context, workspaceID string) (string, error) {
-	workspaces, err := rb.GetWorkspaces(ctx)
-	if err != nil {
-		return "", err
-	}
-	for _, w := range workspaces {
-		if w.ID == workspaceID {
-			return w.Name, nil
-		}
-	}
-	return "", fmt.Errorf("provided workspace id %s does not exist", workspaceID)
-}

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -10,8 +10,6 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
-	"go.uber.org/zap"
 )
 
 type roleBuilder struct {
@@ -103,19 +101,10 @@ func (rb *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, opts r
 		wsNames[w.ID] = w.Name
 	}
 
-	l := ctxzap.Extract(ctx)
 	for _, user := range users {
 		for _, workspace := range user.Workspaces {
 			if workspace.Role == resource.Id.Resource {
-				wsName, ok := wsNames[workspace.WorkspaceID]
-				if !ok {
-					l.Warn("baton-panda-doc: skipping grant for unknown workspace",
-						zap.String("workspace_id", workspace.WorkspaceID),
-						zap.String("user_id", user.ID),
-					)
-					continue
-				}
-				entitlementName := fmt.Sprintf("assigned in workspace %s", wsName)
+				entitlementName := fmt.Sprintf("assigned in workspace %s", wsNames[workspace.WorkspaceID])
 				userResource, _ := parseIntoUserResource(ctx, &user, resource.Id)
 				membershipGrant := grant.NewGrant(resource, entitlementName, userResource, grant.WithAnnotation(&v2.V1Identifier{
 					Id: fmt.Sprintf("workspace-grant:%s:%s:%s", resource.Id.Resource, workspace.MembershipID, workspace.Role),

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"sync"
 
 	"github.com/conductorone/baton-panda-doc/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -15,11 +14,8 @@ import (
 )
 
 type roleBuilder struct {
-	resourceType    *v2.ResourceType
-	client          *client.PandaDocClient
-	connector       *Connector
-	workspaces      []client.Workspace
-	workspacesMutex sync.RWMutex
+	resourceType *v2.ResourceType
+	client       *client.PandaDocClient
 }
 
 func (rb *roleBuilder) ResourceType(_ context.Context) *v2.ResourceType {
@@ -40,18 +36,16 @@ func (rb *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 		rolesResource = append(rolesResource, roleResource)
 	}
 
-	err := rb.connector.cacheUsers(ctx)
-
+	users, err := getUsersFromSession(ctx, rb.client, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	systemRoles := []string{"Admin", "Collaborator", "Member", "Manager"}
+	systemRoleNames := []string{"Admin", "Collaborator", "Member", "Manager"}
 
-	users := rb.connector.cachedUsers
 	for _, user := range users {
 		for _, workspace := range user.Workspaces {
-			if !slices.Contains(systemRoles, workspace.Role) {
+			if !slices.Contains(systemRoleNames, workspace.Role) {
 				newRole := client.Role{
 					Name:        workspace.Role,
 					IsSystem:    false,
@@ -72,13 +66,10 @@ func (rb *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 func (rb *roleBuilder) Entitlements(ctx context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var rv []*v2.Entitlement
 
-	err := rb.GetWorkspaces(ctx)
-
+	workspaces, err := rb.GetWorkspaces(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	workspaces := rb.workspaces
 
 	for _, workspace := range workspaces {
 		permissionName := fmt.Sprintf("assigned in workspace %s", workspace.Name)
@@ -97,13 +88,11 @@ func (rb *roleBuilder) Entitlements(ctx context.Context, resource *v2.Resource, 
 func (rb *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	var grants []*v2.Grant
 
-	err := rb.connector.cacheUsers(ctx)
-
+	users, err := getUsersFromSession(ctx, rb.client, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	users := rb.connector.cachedUsers
 	for _, user := range users {
 		for _, workspace := range user.Workspaces {
 			if workspace.Role == resource.Id.Resource {
@@ -124,11 +113,10 @@ func (rb *roleBuilder) Grants(ctx context.Context, resource *v2.Resource, opts r
 	return grants, nil, nil
 }
 
-func newRolesBuilder(client *client.PandaDocClient, con *Connector) *roleBuilder {
+func newRolesBuilder(client *client.PandaDocClient) *roleBuilder {
 	return &roleBuilder{
 		resourceType: roleResourceType,
 		client:       client,
-		connector:    con,
 	}
 }
 
@@ -151,40 +139,34 @@ func parseIntoRoleResource(_ context.Context, role *client.Role, _ *v2.ResourceI
 	return ret, nil
 }
 
-func (rb *roleBuilder) GetWorkspaces(ctx context.Context) error {
-	rb.workspacesMutex.RLock()
-	defer rb.workspacesMutex.RUnlock()
-
+func (rb *roleBuilder) GetWorkspaces(ctx context.Context) ([]client.Workspace, error) {
 	paginationToken := pagination.Token{
 		Size:  wsPageSize,
 		Token: "",
 	}
 
-	if rb.workspaces != nil {
-		return nil
-	}
-
+	var workspaces []client.Workspace
 	for {
 		bag, pageToken, err := getToken(&paginationToken, workspaceResourceType)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		workspaces, nextPageToken, _, err := rb.client.ListWorkspaces(ctx, client.PageOptions{
+		page, nextPageToken, _, err := rb.client.ListWorkspaces(ctx, client.PageOptions{
 			Count: paginationToken.Size,
 			Page:  pageToken,
 		})
 		if err != nil {
-			return err
+			return nil, err
 		}
 		err = bag.Next(nextPageToken)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		rb.workspaces = append(rb.workspaces, workspaces...)
+		workspaces = append(workspaces, page...)
 		nextPageToken, err = bag.Marshal()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if nextPageToken == "" {
 			break
@@ -192,22 +174,18 @@ func (rb *roleBuilder) GetWorkspaces(ctx context.Context) error {
 		paginationToken.Token = nextPageToken
 	}
 
-	return nil
+	return workspaces, nil
 }
 
 func (rb *roleBuilder) GetWorkspaceName(ctx context.Context, workspaceID string) (string, error) {
-	err := rb.GetWorkspaces(ctx)
-
+	workspaces, err := rb.GetWorkspaces(ctx)
 	if err != nil {
 		return "", err
 	}
-	workspaceMap := make(map[string]string)
-	for _, w := range rb.workspaces {
-		workspaceMap[w.ID] = w.Name
+	for _, w := range workspaces {
+		if w.ID == workspaceID {
+			return w.Name, nil
+		}
 	}
-	if name, exists := workspaceMap[workspaceID]; exists {
-		return name, nil
-	} else {
-		return "", fmt.Errorf("provided workspace id %s does not exists", workspaceID)
-	}
+	return "", fmt.Errorf("provided workspace id %s does not exist", workspaceID)
 }

--- a/pkg/connector/session_cache.go
+++ b/pkg/connector/session_cache.go
@@ -1,0 +1,81 @@
+package connector
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/conductorone/baton-panda-doc/pkg/client"
+	"github.com/conductorone/baton-sdk/pkg/session"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/types/sessions"
+)
+
+const usersCachePrefix = "users"
+
+// getUsersFromSession returns all users, reading from the session store when
+// available and falling back to the API on a miss. On an API fetch the results
+// are written back to the session store so subsequent callers get cache hits
+// regardless of which builder runs first during the List phase.
+func getUsersFromSession(ctx context.Context, c *client.PandaDocClient, opts rs.SyncOpAttrs) ([]client.User, error) {
+	if opts.Session != nil {
+		cached, err := session.GetAllJSON[client.User](ctx, opts.Session,
+			sessions.WithSyncID(opts.SyncID),
+			sessions.WithPrefix(usersCachePrefix),
+		)
+		if err != nil {
+			return nil, err
+		}
+		if len(cached) > 0 {
+			users := make([]client.User, 0, len(cached))
+			for _, u := range cached {
+				users = append(users, u)
+			}
+			return users, nil
+		}
+	}
+
+	// Cache miss or no session: fetch from API.
+	users, err := fetchAllUsers(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Session != nil && len(users) > 0 {
+		toCache := make(map[string]client.User, len(users))
+		for _, u := range users {
+			toCache[u.ID] = u
+		}
+		if err := session.SetManyJSON(ctx, opts.Session, toCache,
+			sessions.WithSyncID(opts.SyncID),
+			sessions.WithPrefix(usersCachePrefix),
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	return users, nil
+}
+
+func fetchAllUsers(ctx context.Context, c *client.PandaDocClient) ([]client.User, error) {
+	var all []client.User
+	pageOptions := client.PageOptions{
+		Count: usersPageSize,
+		Page:  1,
+	}
+	for {
+		users, nextPageToken, _, err := c.ListUsers(ctx, pageOptions)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, users...)
+		if nextPageToken == "" {
+			break
+		}
+		pageToken, err := strconv.Atoi(nextPageToken)
+		if err != nil {
+			return nil, err
+		}
+		pageOptions.Page = pageToken
+	}
+	return all, nil
+}

--- a/pkg/connector/session_cache.go
+++ b/pkg/connector/session_cache.go
@@ -10,7 +10,10 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/types/sessions"
 )
 
-const usersCachePrefix = "users"
+const (
+	usersCachePrefix      = "users"
+	workspacesCachePrefix = "workspaces"
+)
 
 // getUsersFromSession returns all users, reading from the session store when
 // available and falling back to the API on a miss. On an API fetch the results
@@ -68,6 +71,83 @@ func fetchAllUsers(ctx context.Context, c *client.PandaDocClient) ([]client.User
 			return nil, err
 		}
 		all = append(all, users...)
+		if nextPageToken == "" {
+			break
+		}
+		pageToken, err := strconv.Atoi(nextPageToken)
+		if err != nil {
+			return nil, err
+		}
+		pageOptions.Page = pageToken
+	}
+	return all, nil
+}
+
+// getWorkspacesFromSession returns all workspaces, reading from the session
+// store when available. On a miss it fetches all pages from the API and writes
+// them back so subsequent callers hit the cache.
+func getWorkspacesFromSession(ctx context.Context, c *client.PandaDocClient, opts rs.SyncOpAttrs) ([]client.Workspace, error) {
+	if opts.Session != nil {
+		cached, err := session.GetAllJSON[client.Workspace](ctx, opts.Session,
+			sessions.WithSyncID(opts.SyncID),
+			sessions.WithPrefix(workspacesCachePrefix),
+		)
+		if err != nil {
+			return nil, err
+		}
+		if len(cached) > 0 {
+			workspaces := make([]client.Workspace, 0, len(cached))
+			for _, w := range cached {
+				workspaces = append(workspaces, w)
+			}
+			return workspaces, nil
+		}
+	}
+
+	// Cache miss or no session: fetch from API.
+	workspaces, err := fetchAllWorkspaces(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Session != nil && len(workspaces) > 0 {
+		if err := cacheWorkspacesPage(ctx, opts, workspaces); err != nil {
+			return nil, err
+		}
+	}
+
+	return workspaces, nil
+}
+
+// cacheWorkspacesPage writes a slice of workspaces into the session store.
+// Called from workspaceBuilder.List on each fetched page so the cache is
+// populated incrementally as the List phase runs.
+func cacheWorkspacesPage(ctx context.Context, opts rs.SyncOpAttrs, workspaces []client.Workspace) error {
+	if opts.Session == nil || len(workspaces) == 0 {
+		return nil
+	}
+	toCache := make(map[string]client.Workspace, len(workspaces))
+	for _, w := range workspaces {
+		toCache[w.ID] = w
+	}
+	return session.SetManyJSON(ctx, opts.Session, toCache,
+		sessions.WithSyncID(opts.SyncID),
+		sessions.WithPrefix(workspacesCachePrefix),
+	)
+}
+
+func fetchAllWorkspaces(ctx context.Context, c *client.PandaDocClient) ([]client.Workspace, error) {
+	var all []client.Workspace
+	pageOptions := client.PageOptions{
+		Count: wsPageSize,
+		Page:  1,
+	}
+	for {
+		workspaces, nextPageToken, _, err := c.ListWorkspaces(ctx, pageOptions)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, workspaces...)
 		if nextPageToken == "" {
 			break
 		}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/conductorone/baton-panda-doc/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
-	"github.com/conductorone/baton-sdk/pkg/types/resource"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
 type userBuilder struct {
@@ -22,12 +20,12 @@ func (ub *userBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
-func (ub *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (ub *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	var resources []*v2.Resource
 
 	err := ub.connector.cacheUsers(ctx)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	users := ub.connector.cachedUsers
@@ -36,12 +34,12 @@ func (ub *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId
 		userCopy := user
 		userResource, err := parseIntoUserResource(ctx, &userCopy, nil)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 		resources = append(resources, userResource)
 	}
 
-	return resources, "", nil, nil
+	return resources, nil, nil
 }
 
 func parseIntoUserResource(_ context.Context, user *client.User, parentResourceID *v2.ResourceId) (*v2.Resource, error) {
@@ -57,20 +55,20 @@ func parseIntoUserResource(_ context.Context, user *client.User, parentResourceI
 		"owner":      user.IsOrganizationOwner,
 	}
 
-	userTraits := []resource.UserTraitOption{
-		resource.WithUserProfile(profile),
-		resource.WithStatus(userStatus),
-		resource.WithEmail(user.Email, true),
+	userTraits := []rs.UserTraitOption{
+		rs.WithUserProfile(profile),
+		rs.WithStatus(userStatus),
+		rs.WithEmail(user.Email, true),
 	}
 
 	displayName := user.Email
 
-	ret, err := resource.NewUserResource(
+	ret, err := rs.NewUserResource(
 		displayName,
 		userResourceType,
 		user.ID,
 		userTraits,
-		resource.WithParentResourceID(parentResourceID),
+		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {
 		return nil, err
@@ -80,13 +78,13 @@ func parseIntoUserResource(_ context.Context, user *client.User, parentResourceI
 }
 
 // Entitlements always returns an empty slice for users.
-func (ub *userBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (ub *userBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 // Grants always returns an empty slice for users since they don't have any entitlements.
-func (ub *userBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	return nil, "", nil, nil
+func (ub *userBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func newUserBuilder(c *client.PandaDocClient, con *Connector) *userBuilder {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -12,7 +12,6 @@ import (
 type userBuilder struct {
 	resourceType *v2.ResourceType
 	client       *client.PandaDocClient
-	connector    *Connector
 }
 
 func (ub *userBuilder) ResourceType(ctx context.Context) *v2.ResourceType {

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -3,9 +3,10 @@ package connector
 import (
 	"context"
 
-	"github.com/conductorone/baton-panda-doc/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+
+	"github.com/conductorone/baton-panda-doc/pkg/client"
 )
 
 type userBuilder struct {
@@ -20,16 +21,15 @@ func (ub *userBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
 
 // List returns all the users from the database as resource objects.
 // Users include a UserTrait because they are the 'shape' of a standard user.
+// Users are also written to the session store so that roles and workspaces
+// builders can read them without re-fetching from the API.
 func (ub *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	var resources []*v2.Resource
-
-	err := ub.connector.cacheUsers(ctx)
+	users, err := getUsersFromSession(ctx, ub.client, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	users := ub.connector.cachedUsers
-
+	resources := make([]*v2.Resource, 0, len(users))
 	for _, user := range users {
 		userCopy := user
 		userResource, err := parseIntoUserResource(ctx, &userCopy, nil)
@@ -87,10 +87,9 @@ func (ub *userBuilder) Grants(ctx context.Context, resource *v2.Resource, opts r
 	return nil, nil, nil
 }
 
-func newUserBuilder(c *client.PandaDocClient, con *Connector) *userBuilder {
+func newUserBuilder(c *client.PandaDocClient) *userBuilder {
 	return &userBuilder{
 		resourceType: userResourceType,
 		client:       c,
-		connector:    con,
 	}
 }

--- a/pkg/connector/workspaces.go
+++ b/pkg/connector/workspaces.go
@@ -6,11 +6,9 @@ import (
 
 	"github.com/conductorone/baton-panda-doc/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
-	"github.com/conductorone/baton-sdk/pkg/annotations"
-	"github.com/conductorone/baton-sdk/pkg/pagination"
 	"github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
-	"github.com/conductorone/baton-sdk/pkg/types/resource"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
 type workspaceBuilder struct {
@@ -27,12 +25,13 @@ func (wb *workspaceBuilder) ResourceType(_ context.Context) *v2.ResourceType {
 	return workspaceResourceType
 }
 
-func (wb *workspaceBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, pToken *pagination.Token) ([]*v2.Resource, string, annotations.Annotations, error) {
+func (wb *workspaceBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
 	var resources []*v2.Resource
+	pToken := &opts.PageToken
 	bag, pageToken, err := getToken(pToken, workspaceResourceType)
 
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	workspaces, nextPage, annotation, err := wb.client.ListWorkspaces(ctx, client.PageOptions{
@@ -40,27 +39,27 @@ func (wb *workspaceBuilder) List(ctx context.Context, parentResourceID *v2.Resou
 		Count: wsPageSize,
 	})
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	err = bag.Next(nextPage)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 	nextPage, err = bag.Marshal()
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	for _, workspace := range workspaces {
 		workspaceResource, err := parseIntoWorkspaceResource(workspace)
 		if err != nil {
-			return nil, "", nil, err
+			return nil, nil, err
 		}
 		resources = append(resources, workspaceResource)
 	}
 
-	return resources, nextPage, annotation, nil
+	return resources, &rs.SyncOpResults{NextPageToken: nextPage, Annotations: annotation}, nil
 }
 
 // This function parses a workspace from PandaDoc into a Workspace Resource.
@@ -72,11 +71,11 @@ func parseIntoWorkspaceResource(workspace client.Workspace) (*v2.Resource, error
 		"date_created": workspace.DateCreated.Format(time.RFC3339),
 	}
 
-	groupTraits := []resource.GroupTraitOption{
-		resource.WithGroupProfile(profile),
+	groupTraits := []rs.GroupTraitOption{
+		rs.WithGroupProfile(profile),
 	}
 
-	ret, err := resource.NewGroupResource(
+	ret, err := rs.NewGroupResource(
 		workspace.Name,
 		workspaceResourceType,
 		workspace.ID,
@@ -90,7 +89,7 @@ func parseIntoWorkspaceResource(workspace client.Workspace) (*v2.Resource, error
 	return ret, nil
 }
 
-func (wb *workspaceBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Entitlement, string, annotations.Annotations, error) {
+func (wb *workspaceBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
 	var entitlements []*v2.Entitlement
 
 	assigmentOptions := []entitlement.EntitlementOption{
@@ -101,10 +100,10 @@ func (wb *workspaceBuilder) Entitlements(_ context.Context, resource *v2.Resourc
 
 	entitlements = append(entitlements, entitlement.NewPermissionEntitlement(resource, permissionName, assigmentOptions...))
 
-	return entitlements, "", nil, nil
+	return entitlements, nil, nil
 }
 
-func (wb *workspaceBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
+func (wb *workspaceBuilder) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	var grants []*v2.Grant
 
 	var workspaceId = resource.Id.Resource
@@ -112,7 +111,7 @@ func (wb *workspaceBuilder) Grants(ctx context.Context, resource *v2.Resource, p
 	err := wb.connector.cacheUsers(ctx)
 
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
 
 	users := wb.connector.cachedUsers
@@ -126,7 +125,7 @@ func (wb *workspaceBuilder) Grants(ctx context.Context, resource *v2.Resource, p
 			}
 		}
 	}
-	return grants, "", nil, nil
+	return grants, nil, nil
 }
 
 func newWorkspaceBuilder(client *client.PandaDocClient, con *Connector) *workspaceBuilder {

--- a/pkg/connector/workspaces.go
+++ b/pkg/connector/workspaces.go
@@ -50,6 +50,10 @@ func (wb *workspaceBuilder) List(ctx context.Context, parentResourceID *v2.Resou
 		return nil, nil, err
 	}
 
+	if err := cacheWorkspacesPage(ctx, opts, workspaces); err != nil {
+		return nil, nil, err
+	}
+
 	for _, workspace := range workspaces {
 		workspaceResource, err := parseIntoWorkspaceResource(workspace)
 		if err != nil {

--- a/pkg/connector/workspaces.go
+++ b/pkg/connector/workspaces.go
@@ -14,7 +14,6 @@ import (
 type workspaceBuilder struct {
 	resourceType *v2.ResourceType
 	client       *client.PandaDocClient
-	connector    *Connector
 }
 
 const wsPageSize = 100
@@ -108,13 +107,10 @@ func (wb *workspaceBuilder) Grants(ctx context.Context, resource *v2.Resource, o
 
 	var workspaceId = resource.Id.Resource
 
-	err := wb.connector.cacheUsers(ctx)
-
+	users, err := getUsersFromSession(ctx, wb.client, opts)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	users := wb.connector.cachedUsers
 
 	for _, user := range users {
 		for _, workspace := range user.Workspaces {
@@ -128,10 +124,9 @@ func (wb *workspaceBuilder) Grants(ctx context.Context, resource *v2.Resource, o
 	return grants, nil, nil
 }
 
-func newWorkspaceBuilder(client *client.PandaDocClient, con *Connector) *workspaceBuilder {
+func newWorkspaceBuilder(client *client.PandaDocClient) *workspaceBuilder {
 	return &workspaceBuilder{
 		resourceType: workspaceResourceType,
 		client:       client,
-		connector:    con,
 	}
 }


### PR DESCRIPTION
Containerizes the baton-panda-doc connector per the containerization guide.

Changes:
- Migrated to ConnectorBuilderV2 / ResourceSyncerV2
- Updated config.go with display names, icon URL, help URL
- Added pkg/config/gen/gen.go for config generation
- Updated Makefile with BATON_LAMBDA_SUPPORT build tag support
- Updated main.go to use config.RunConnector
- Cleaned up legacy CI workflow files
- Replaced in-memory user cache with session store so users are shared across builders without re-fetching
- Added workspace session cache: workspaces are written to the session store page-by-page during the List phase and read back by roles.Entitlements and roles.Grants, eliminating redundant full workspace list fetches in the Grants loop

Linear: CXH-1890