### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -131,15 +131,13 @@ func parseIntoRoleResource(_ context.Context, role *client.Role, _ *v2.ResourceI
 		"is_system": role.IsSystem,
 	}
 
-	roleTraits := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	roleTraits := []rs.RoleTraitOption{}
 
-	ret, err := rs.NewRoleResource(role.Name, roleResourceType, role.Name, roleTraits)
+	ret, err := rs.NewRoleResource(role.Name, roleResourceType, role.Name, roleTraits,
+		rs.WithResourceProfile(profile))
 	if err != nil {
 		return nil, err
 	}
 
 	return ret, nil
 }
-

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -55,8 +55,6 @@ func parseIntoUserResource(_ context.Context, user *client.User, parentResourceI
 	}
 
 	userTraits := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithStatus(userStatus),
 		rs.WithEmail(user.Email, true),
 	}
 
@@ -67,6 +65,8 @@ func parseIntoUserResource(_ context.Context, user *client.User, parentResourceI
 		userResourceType,
 		user.ID,
 		userTraits,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {

--- a/pkg/connector/workspaces.go
+++ b/pkg/connector/workspaces.go
@@ -74,15 +74,14 @@ func parseIntoWorkspaceResource(workspace client.Workspace) (*v2.Resource, error
 		"date_created": workspace.DateCreated.Format(time.RFC3339),
 	}
 
-	groupTraits := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	groupTraits := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		workspace.Name,
 		workspaceResourceType,
 		workspace.ID,
 		groupTraits,
+		rs.WithResourceProfile(profile),
 	)
 
 	if err != nil {


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
